### PR TITLE
Hist rates

### DIFF
--- a/lib/ecb/rate_setter.rb
+++ b/lib/ecb/rate_setter.rb
@@ -1,0 +1,50 @@
+module ECB
+  class RateSetter
+    attr_reader :store
+
+    LEGACY_CURRENCIES = %w(CYP SIT ROL TRL)
+
+    def initialize(rates_document = nil, type = nil)
+      @rates_document = rates_document
+      @type = type
+    end
+
+    def update_rates(store)
+      store.transaction true do
+        copy_rates(@rates_document, store) if @type == :current
+        copy_rates(@rates_document, store, true) if @type == :historical
+      end
+      [@rates_document.updated_at, Time.now]
+    end
+
+    def set_rate(store, from, to, rate, date = nil)
+      # Backwards compatibility for the opts hash
+      date = date[:date] if date.is_a?(Hash)
+      store.add_rate(::Money::Currency.wrap(from).iso_code, ::Money::Currency.wrap(to).iso_code, rate, date)
+    end
+
+    private
+
+    def copy_rates(rates_document, store, with_date = false)
+      rates_document.rates.each do |date, rates|
+        rates.each do |currency, rate|
+          next if LEGACY_CURRENCIES.include?(currency)
+          set_rate(store, 'EUR', currency, BigDecimal(rate), with_date ? date : nil)
+        end
+        set_rate(store, 'EUR', 'EUR', 1, with_date ? date : nil)
+      end
+    end
+  end
+
+  class CurrentRateSetter < RateSetter
+    def initialize(rates_document)
+      super(rates_document, :current)
+    end
+  end
+
+  class HistoricalRateSetter < RateSetter
+    def initialize(rates_document)
+      super(rates_document, :historical)
+    end
+  end
+end

--- a/lib/eu_central_bank.rb
+++ b/lib/eu_central_bank.rb
@@ -92,19 +92,14 @@ class EuCentralBank < Money::Bank::VariableExchange
     check_currency_available(from)
     check_currency_available(to)
 
-    if date.is_a?(Hash)
-      # Backwards compatibility for the opts hash
-      date = date[:date]
-    end
-
+    # Backwards compatibility for the opts hash
+    date = date[:date] if date.is_a?(Hash)
     store.get_rate(::Money::Currency.wrap(from).iso_code, ::Money::Currency.wrap(to).iso_code, date)
   end
 
   def set_rate(from, to, rate, date = nil)
-    if date.is_a?(Hash)
-      # Backwards compatibility for the opts hash
-      date = date[:date]
-    end
+    # Backwards compatibility for the opts hash
+    date = date[:date] if date.is_a?(Hash)
     store.add_rate(::Money::Currency.wrap(from).iso_code, ::Money::Currency.wrap(to).iso_code, rate, date)
   end
 
@@ -117,8 +112,7 @@ class EuCentralBank < Money::Bank::VariableExchange
   end
 
   def export_rates(format, file = nil, opts = {})
-    raise Money::Bank::UnknownRateFormat unless
-      RATE_FORMATS.include? format
+    raise Money::Bank::UnknownRateFormat unless RATE_FORMATS.include? format
 
     store.transaction true do
       s = case format


### PR DESCRIPTION
Hi, from the PR request on the main repository I was looking at refactoring update_parsed_rates(doc) and update_historical_parsed_rates(doc). I saw that you had already done it with boolean, I tried to clear it up a little more by adding a RateSetter class. I'm not really sure about passing the store into this and if require_relative helps in any way. Any way let me know what you think please.